### PR TITLE
printOnly argument: just print to console md5 of the file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ gulp.src("./src/*.ext")
 
 ## API
 
+### md5({printOnly: True})
+
+#### printOnly
+Type: `Boolean`  
+Default: false
+
+Optional: you can pass printOnly to skip md5 appending to filenames and just print md5 of file to console.
+
 ### md5(size)
 
 #### size

--- a/index.js
+++ b/index.js
@@ -4,15 +4,16 @@ var path = require('path')
   , crypto = require('crypto');
 
 module.exports = function(options) {
-  var separator,
-    size;
+  var separator, size, printOnly;
 
   if (typeof options === 'object') {
+    printOnly = options.printOnly || false;
     separator = options.separator || '_';
     size = options.size | 0;
   } else {
     size = options | 0;
     separator = '_';
+    printOnly = false;
   }
 
   return through.obj(function(file, enc, cb) {
@@ -24,6 +25,11 @@ module.exports = function(options) {
     var md5Hash = calcMd5(file, size),
       filename = path.basename(file.path),
       dir;
+
+    if (printOnly) {
+      gutil.log(filename + ' ' + md5Hash);
+      return cb(null, file)
+    }
 
     if (file.path[0] == '.') {
       dir = path.join(file.base, file.path);


### PR DESCRIPTION
Hi there. I was looking for gulp md5 module to print md5 of pipe's files to the console. Your module is what i need, but w/o printing md5 functionality.
Just added few lines of code.
