### PR TITLE
stop using `gulp-util`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var path = require('path')
-  , gutil = require('gulp-util')
+  , log = require('fancy-log')
+  , PluginError = require('plugin-error')
   , through = require('through2')
   , crypto = require('crypto');
 
@@ -18,7 +19,7 @@ module.exports = function(options) {
 
   return through.obj(function(file, enc, cb) {
     if (file.isStream()) {
-      this.emit('error', new gutil.PluginError('gulp-debug', 'Streaming not supported'));
+      this.emit('error', new PluginError('gulp-debug', 'Streaming not supported'));
       return cb();
     }
 
@@ -27,7 +28,7 @@ module.exports = function(options) {
       dir;
 
     if (printOnly) {
-      gutil.log(filename + ' ' + md5Hash);
+      log(filename + ' ' + md5Hash);
       return cb(null, file)
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-md5",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "add md5 to filename",
   "main": "index.js",
   "scripts": {
@@ -15,7 +15,8 @@
     "gulp-md5"
   ],
   "dependencies": {
-    "gulp-util": "~2.2.14",
+    "fancy-log": "~1.3.3",
+    "plugin-error": "~1.0.1",
     "through2": "^0.4.1"
   },
   "homepage": "https://github.com/Raistlin916/gulp-md5.git",


### PR DESCRIPTION
`gulp-util` has been deprecated since the end of 2017. Some of its
dependencies are causing us to have security alerts (even though I know
this is only the build system).

I have also taken the liberty of bumping the version number. Feel free to
update any way you see fit.